### PR TITLE
Add timer and game over enhancements

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
+    />
     <title>UNNO</title>
     <link rel="stylesheet" href="style.css" />
   </head>
@@ -14,6 +17,7 @@
     </header>
     <div id="game">
       <div id="status"></div>
+      <div id="timer">0.00s</div>
       <div id="ai-hand" class="hand">
         <div id="ai-count">AI: 0 cards</div>
       </div>

--- a/script.js
+++ b/script.js
@@ -19,6 +19,7 @@ function shuffle(array) {
 }
 
 let deck, playerHand, aiHand, discard;
+let startTime, timerInterval;
 
 function init() {
   deck = createDeck();
@@ -31,6 +32,7 @@ function init() {
   discard = [deck.pop()];
   render();
   updateStatus('Your turn');
+  startTimer();
 }
 
 function cardToHTML(card, index, clickable = true) {
@@ -120,6 +122,19 @@ function updateStatus(msg) {
   document.getElementById('status').textContent = msg;
 }
 
+function startTimer() {
+  startTime = Date.now();
+  timerInterval = setInterval(() => {
+    const elapsed = ((Date.now() - startTime) / 1000).toFixed(2);
+    document.getElementById('timer').textContent = `${elapsed}s`;
+  }, 100);
+}
+
+function stopTimer() {
+  clearInterval(timerInterval);
+  return (Date.now() - startTime) / 1000;
+}
+
 function createConfetti() {
   const colors = ['#ff6b6b', '#4ecdc4', '#45b7d1', '#96ceb4', '#feca57', '#ff9ff3', '#54a0ff'];
   
@@ -144,30 +159,40 @@ function showGameOverEffect(playerWon) {
   const drawButton = document.getElementById('draw-button');
   const restartButton = document.getElementById('restart-button');
   const overlay = document.getElementById('game-over-overlay');
-  
+
   drawButton.style.display = 'none';
   restartButton.style.display = 'block';
-  
+  const time = stopTimer();
+  let best = parseFloat(localStorage.getItem('bestTime'));
   if (playerWon) {
+    if (!best || time < best) {
+      best = time;
+      localStorage.setItem('bestTime', best);
+    }
+    overlay.style.background = 'rgba(0, 0, 0, 0)';
     createConfetti();
   } else {
-    overlay.classList.add('show');
+    overlay.style.background = 'rgba(0, 0, 0, 0.9)';
     document.getElementById('game').classList.add('shake');
     setTimeout(() => {
       document.getElementById('game').classList.remove('shake');
     }, 500);
   }
+  const bestDisplay = best ? Number(best).toFixed(2) : '--';
+  overlay.innerHTML = `<div>${playerWon ? 'You Win!' : 'You Lose!'}</div><div class="time">Time: ${time.toFixed(2)}s<br>Best: ${bestDisplay}s</div>`;
+  overlay.classList.add('show');
 }
 
 function resetGame() {
   const drawButton = document.getElementById('draw-button');
   const restartButton = document.getElementById('restart-button');
   const overlay = document.getElementById('game-over-overlay');
-  
+
   drawButton.style.display = 'block';
   restartButton.style.display = 'none';
   overlay.classList.remove('show');
-  
+  overlay.innerHTML = '';
+  document.getElementById('timer').textContent = '0.00s';
   init();
 }
 

--- a/style.css
+++ b/style.css
@@ -94,6 +94,13 @@ h1 {
   text-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
 }
 
+#timer {
+  margin-top: 0.5rem;
+  font-size: 1.2rem;
+  font-weight: bold;
+  text-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
+}
+
 .card:hover {
   transform: scale(1.1);
 }
@@ -166,14 +173,26 @@ h1 {
   width: 100vw;
   height: 100vh;
   background: rgba(0, 0, 0, 0.7);
-  z-index: 500;
+  z-index: 1001;
   pointer-events: none;
   opacity: 0;
-  transition: opacity 1s ease;
+  transition: opacity 0.5s ease;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  color: #fff;
+  font-size: 3rem;
+  text-align: center;
 }
 
 .game-over-overlay.show {
   opacity: 1;
+}
+
+.game-over-overlay .time {
+  font-size: 1.5rem;
+  margin-top: 1rem;
 }
 
 @keyframes shake {


### PR DESCRIPTION
## Summary
- Prevent mobile zooming and display in-game timer
- Show full-screen win/lose overlay with dark background on AI victories
- Track and display best player win times using localStorage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68adce53bfc883258c8f0d42ea5e7b5f