### PR TITLE
Simplify viewport meta tag to prevent zoom

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,10 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-    />
+    <meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,user-scalable=no" />
     <title>UNNO</title>
     <link rel="stylesheet" href="style.css" />
   </head>


### PR DESCRIPTION
## Summary
- tighten viewport meta tag values to avoid mobile zooming

## Testing
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae4c6c84908325b26093efb0011e4d