### PR TITLE
style: adjust AI card back text

### DIFF
--- a/script.js
+++ b/script.js
@@ -48,8 +48,8 @@ function render() {
   const aiDiv = document.getElementById('ai-hand');
   const aiCountDiv = document.getElementById('ai-count');
   aiCountDiv.textContent = `AI: ${aiHand.length} cards`;
-  const aiCardsHTML = aiHand.map((_, i) => 
-    `<div class="card card-back" data-index="${i}">UNNO</div>`
+  const aiCardsHTML = aiHand.map((_, i) =>
+    `<div class="card card-back" data-index="${i}"><span class="card-back-text">UNNO</span></div>`
   ).join('');
   aiDiv.innerHTML = `<div id="ai-count">AI: ${aiHand.length} cards</div>` + aiCardsHTML;
   

--- a/style.css
+++ b/style.css
@@ -85,9 +85,21 @@ h1 {
 
 .card-back {
   background: linear-gradient(45deg, #1e3c72, #2a5298);
-  color: #fff;
   font-weight: bold;
   cursor: default;
+}
+
+.card-back-text {
+  color: #ff0;
+  -webkit-text-stroke: 1px #fff;
+  text-shadow: 2px 2px 2px rgba(0, 0, 0, 0.5);
+  font-size: 14px;
+  transform: rotate(12deg);
+  display: inline-block;
+}
+
+.card-back:hover .card-back-text {
+  transform: rotate(12deg) scale(1.1);
 }
 
 #ai-count {
@@ -119,6 +131,9 @@ h1 {
     width: 40px;
     height: 60px;
     font-size: 16px;
+  }
+  .card-back-text {
+    font-size: 10px;
   }
 }
 


### PR DESCRIPTION
## Summary
- Shrink and rotate AI card back "UNNO" label
- Add yellow text with white outline and shadow
- Keep text size responsive on small screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d4564660832595768c636eb9dd1f